### PR TITLE
Fix to completion_callback

### DIFF
--- a/trace_generator/trace_generator.h
+++ b/trace_generator/trace_generator.h
@@ -127,7 +127,7 @@ std::chrono::nanoseconds ReplayTrace(const Trace<QueryType> &trace,
 
     // TODO(tjablin): The completion callback should record the result of the
     // inference.
-    auto completion_callback = [&] {
+    auto completion_callback = [i, query_start_time, &latencies] {
       latencies[i] =
           std::chrono::high_resolution_clock::now() - query_start_time;
     };


### PR DESCRIPTION
The index `i` and the start time `query_start_time` should be captured by value, not reference.  

If the `enqueue` function is multi-threaded, `enqueue` can return prior to the execution of `completion_callback`, which creates a race condition on the variables that change with each loop iteration.